### PR TITLE
feat: Add RestoreEntity

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .history
+configuration.yaml

--- a/hkaura_plus/number.py
+++ b/hkaura_plus/number.py
@@ -1,5 +1,7 @@
 # number.py
 from homeassistant.components.number import NumberEntity
+from homeassistant.helpers.restore_state import RestoreEntity
+
 from . import DOMAIN
 import logging
 
@@ -12,10 +14,11 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
         HKAuraVolumeControl(device)
     ], True)
 
-class HKAuraBassControl(NumberEntity):
+class HKAuraBassControl(NumberEntity, RestoreEntity):
     def __init__(self, device):
         self._device = device
         self._bass = 20
+
 
     @property
     def name(self):
@@ -41,6 +44,11 @@ class HKAuraBassControl(NumberEntity):
     def native_step(self):
         return 1
 
+    async def async_added_to_hass(self):
+            last_state = await self.async_get_last_state()
+            if last_state and last_state.state.isdigit():
+                self._bass = int(last_state.state)
+
     async def async_set_native_value(self, value: float) -> None:
         bass = int(value)
         _LOGGER.debug(f"Setting bass to: {bass}")
@@ -48,7 +56,7 @@ class HKAuraBassControl(NumberEntity):
         self._bass = bass
         self.async_write_ha_state()
 
-class HKAuraVolumeControl(NumberEntity):
+class HKAuraVolumeControl(NumberEntity, RestoreEntity):
     def __init__(self, device):
         self._device = device
         self._volume = 20
@@ -76,6 +84,11 @@ class HKAuraVolumeControl(NumberEntity):
     @property
     def native_step(self):
         return 1
+
+    async def async_added_to_hass(self):
+        last_state = await self.async_get_last_state()
+        if last_state and last_state.state.isdigit():
+            self._volume = int(last_state.state)
 
     async def async_set_native_value(self, value: float) -> None:
         volume = int(value)

--- a/hkaura_plus/switch.py
+++ b/hkaura_plus/switch.py
@@ -1,5 +1,7 @@
 # switch.py
 from homeassistant.components.switch import SwitchEntity
+from homeassistant.helpers.restore_state import RestoreEntity
+
 from . import DOMAIN
 import logging
 
@@ -13,7 +15,7 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
     ], True)
 
 
-class HKAuraEQSwitch(SwitchEntity):
+class HKAuraEQSwitch(SwitchEntity, RestoreEntity):
     def __init__(self, device):
         self._device = device
         self._is_on = False
@@ -36,11 +38,16 @@ class HKAuraEQSwitch(SwitchEntity):
         self._is_on = False
         self.schedule_update_ha_state()
 
+    async def async_added_to_hass(self):
+        last_state = await self.async_get_last_state()
+        if last_state and last_state.state == "on":
+            self._is_on = True
+
     async def async_update(self):
         pass
 
 
-class HKAuraMuteSwitch(SwitchEntity):
+class HKAuraMuteSwitch(SwitchEntity, RestoreEntity):
     def __init__(self, device):
         self._device = device
         self._is_on = False
@@ -62,6 +69,11 @@ class HKAuraMuteSwitch(SwitchEntity):
         self._device.send_command("mute-off")
         self._is_on = False
         self.schedule_update_ha_state()
+
+    async def async_added_to_hass(self):
+        last_state = await self.async_get_last_state()
+        if last_state and last_state.state == "on":
+            self._is_on = True
 
     async def async_update(self):
         pass


### PR DESCRIPTION
This pull request enhances the `hkaura_plus` integration by adding state restoration functionality to `NumberEntity` and `SwitchEntity` components. The changes ensure that entities retain their state across Home Assistant restarts, improving user experience and reliability.

### State Restoration for Number Entities:
* [`hkaura_plus/number.py`](diffhunk://#diff-9065b043a1fbe5dfe19a34c8082392439307f3158aac747a2bd98929e5fc3e2eR3-R4): Added `RestoreEntity` to `HKAuraBassControl` and `HKAuraVolumeControl` classes to enable state restoration. Implemented `async_added_to_hass` to retrieve and apply the last saved state for bass and volume levels. [[1]](diffhunk://#diff-9065b043a1fbe5dfe19a34c8082392439307f3158aac747a2bd98929e5fc3e2eR3-R4) [[2]](diffhunk://#diff-9065b043a1fbe5dfe19a34c8082392439307f3158aac747a2bd98929e5fc3e2eL15-R22) [[3]](diffhunk://#diff-9065b043a1fbe5dfe19a34c8082392439307f3158aac747a2bd98929e5fc3e2eR47-R59) [[4]](diffhunk://#diff-9065b043a1fbe5dfe19a34c8082392439307f3158aac747a2bd98929e5fc3e2eR88-R92)

### State Restoration for Switch Entities:
* [`hkaura_plus/switch.py`](diffhunk://#diff-ade6a8d56c4d31f77d595fb43c9d4e90fad97c5af1be769c32498b86615f1184R3-R4): Added `RestoreEntity` to `HKAuraEQSwitch` and `HKAuraMuteSwitch` classes to enable state restoration. Implemented `async_added_to_hass` to retrieve and apply the last saved state for switch status (on/off). [[1]](diffhunk://#diff-ade6a8d56c4d31f77d595fb43c9d4e90fad97c5af1be769c32498b86615f1184R3-R4) [[2]](diffhunk://#diff-ade6a8d56c4d31f77d595fb43c9d4e90fad97c5af1be769c32498b86615f1184L16-R18) [[3]](diffhunk://#diff-ade6a8d56c4d31f77d595fb43c9d4e90fad97c5af1be769c32498b86615f1184R41-R50) [[4]](diffhunk://#diff-ade6a8d56c4d31f77d595fb43c9d4e90fad97c5af1be769c32498b86615f1184R73-R77)