### PR TITLE
feat(config_flow): add reconfigure step for media_player_entity updates

### DIFF
--- a/custom_components/hkaura_plus/config_flow.py
+++ b/custom_components/hkaura_plus/config_flow.py
@@ -57,6 +57,45 @@ class HKAuraPlusConfigFlow(ConfigFlow, domain=DOMAIN):
             errors=errors,
         )
 
+    async def async_step_reconfigure(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle reconfiguration — allows updating media_player_entity after MA updates."""
+        errors: dict[str, str] = {}
+        entry = self.hass.config_entries.async_get_entry(self.context["entry_id"])
+        assert entry is not None
+
+        if user_input is not None:
+            host = user_input[CONF_HOST]
+            port = user_input[CONF_PORT]
+
+            if await self._test_connection(host, port):
+                return self.async_update_reload_and_abort(
+                    entry,
+                    data=user_input,
+                    reason="reconfigure_successful",
+                )
+            errors["base"] = "cannot_connect"
+
+        # Pre-fill form with existing values
+        current = entry.data
+        reconfigure_schema = vol.Schema(
+            {
+                vol.Required(CONF_HOST, default=current.get(CONF_HOST, "")): str,
+                vol.Required(CONF_PORT, default=current.get(CONF_PORT, DEFAULT_PORT)): int,
+                vol.Optional(
+                    CONF_MEDIA_PLAYER_ENTITY,
+                    default=current.get(CONF_MEDIA_PLAYER_ENTITY, ""),
+                ): str,
+            }
+        )
+
+        return self.async_show_form(
+            step_id="reconfigure",
+            data_schema=reconfigure_schema,
+            errors=errors,
+        )
+
     async def _test_connection(self, host: str, port: int) -> bool:
         """Test if we can connect to the device."""
         try:

--- a/custom_components/hkaura_plus/manifest.json
+++ b/custom_components/hkaura_plus/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "hkaura_plus",
   "name": "HK Aura Plus Speaker",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "config_flow": true,
   "documentation": "https://github.com/vakintosh/harman_kardon_aura_HA",
   "integration_type": "device",

--- a/custom_components/hkaura_plus/strings.json
+++ b/custom_components/hkaura_plus/strings.json
@@ -12,7 +12,21 @@
         "data_description": {
           "host": "The IP address of your HK Aura Plus speaker.",
           "port": "The TCP port for communication (default: 10025).",
-          "media_player_entity": "Entity ID of a media player to sync volume with (e.g. media_player.spotify)."
+          "media_player_entity": "Entity ID of the Music Assistant media player for this speaker (e.g. media_player.hk_aura_wf)."
+        }
+      },
+      "reconfigure": {
+        "title": "Reconfigure HK Aura Plus Speaker",
+        "description": "Update the connection settings or linked Music Assistant media player entity.",
+        "data": {
+          "host": "IP Address",
+          "port": "Port",
+          "media_player_entity": "Media Player Entity (optional)"
+        },
+        "data_description": {
+          "host": "The IP address of your HK Aura Plus speaker.",
+          "port": "The TCP port for communication (default: 10025).",
+          "media_player_entity": "Entity ID of the Music Assistant media player for this speaker (e.g. media_player.hk_aura_wf)."
         }
       }
     },
@@ -20,7 +34,8 @@
       "cannot_connect": "Cannot connect to the speaker. Please check the IP address and port."
     },
     "abort": {
-      "already_configured": "This speaker is already configured."
+      "already_configured": "This speaker is already configured.",
+      "reconfigure_successful": "Re-configuration was successful."
     }
   },
   "entity": {


### PR DESCRIPTION
## Problem

Music Assistant **2.8** introduced a breaking change: players that support multiple protocols are now merged into a single unified entity. This caused the `media_player_entity` stored during initial setup (e.g. `media_player.hk_aura_airplay`) to be silently replaced by a new entity ID (e.g. `media_player.hk_aura_wf`).

Because the integration had no `reconfigure` step, users had no way to update this value through the UI after initial setup — the stale entity ID was locked in `core.config_entries`, silently breaking any automations or behaviour relying on it.

## Root cause

`HKAuraPlusConfigFlow` only implemented `async_step_user`. Without `async_step_reconfigure`, the **Reconfigure** option never appears in the integration's `⋮` menu in Home Assistant.

## Solution

Add `async_step_reconfigure` to `HKAuraPlusConfigFlow`:

- Pre-fills the form with existing `host` / `port` / `media_player_entity` values
- Tests the TCP connection before saving (same validation as initial setup)
- Uses `async_update_reload_and_abort` to atomically persist and reload the entry
- Adds the required translation strings (`reconfigure` step + `reconfigure_successful` abort reason)

After this change, users can update the linked MA entity via:
> **Settings → Devices & Services → HK Aura Plus → ⋮ → Reconfigure**

## Changes

| File | Change |
|---|---|
| `config_flow.py` | Added `async_step_reconfigure` |
| `strings.json` | Added `reconfigure` step strings + `reconfigure_successful` abort |
| `manifest.json` | Version bumped `0.3.0` → `0.4.0` |

## Testing

Verified on a live HA instance running MA 2.8.6 — the Reconfigure option appears in the UI and correctly updates `core.config_entries`.